### PR TITLE
Implement comment scraping

### DIFF
--- a/hnscraper.py
+++ b/hnscraper.py
@@ -103,8 +103,8 @@ class StoryScraper(object):
   """hacker news story scraper.
 
   Example:
-      Story.Scraper.scrape("story", 1394901958) will return all stories since
-      15 Mar 2014 16:45:58 GMT.
+      StoryScraper.getStories("story", 1394901958) will return all
+      stories since 15 Mar 2014 16:45:58 GMT.
   """
 
   @staticmethod
@@ -137,4 +137,48 @@ class StoryScraper(object):
     }
 
     return Scraper().scrape("story", since, until, fields)
+
+
+class CommentScraper(object):
+  """hacker news comment scraper.
+
+  Example:
+      CommentScraper.getComments("comment", 1394901958) will return all
+      comments since 15 Mar 2014 16:45:58 GMT.
+  """
+
+  @staticmethod
+  def getComments(since, until=None):
+    """Scrape comments between 2 timestamps.
+
+    Params:
+      since: timestamp representing how old the comments should be.
+
+    Optional params:
+      until: timestamp representing how new the coments should be.
+
+    Yields:
+      One comment. This is a dict.
+
+    Excepts:
+      TooManyItemsException.
+    """
+
+    # These are the fields that the response will contain.
+    fields = {
+        "created_at": "created_at",
+        "title": "title",
+        "url": "url",
+        "comment_text": "comment_text",
+        "story_id": "story_id",
+        "story_title": "story_title",
+        "story_url": "story_url",
+        "author": "author",
+        "points": "points",
+        "timestamp": "created_at_i",
+        "comment_id": "objectID",
+        "parent_id": "parent_id",
+    }
+
+    return Scraper().scrape("comment", since, until, fields)
 


### PR DESCRIPTION
## Need

I want to be able to fetch comments created since a timestamp.
## Deliverables

``` gherkin
Scenario: Scraping comments
Given I have a timestamp
When I call the scraper
Then it will return all the comments created since that timestamp
```

``` gherkin
Scenario: Scraping too many comments
Given I have a timestamp
And there are more than 50 * 20 comments since that timestamp
When I call the scraper
Then it will return all the comments created since that timestamp
And throw an exception informing me that there are more comments left that couldn't be fetched by the API
```

``` gherkin
Scenario: No comments since timestamp
Given I have a timestamp
And there aren't any new comments since that timestamp
When I call the scraper
Then it will return an empty iterator
```

A returned comment could look like this

``` json
{
  "created_at": "2014-03-13T10:00:44.000Z",
  "title": "DeepFace: Closing the Gap to Human-Level Performance in Face Verification",
  "url": "https://www.facebook.com/publications/546316888800776/",
  "comment_text": "blah blah blah",
  "story_id": 7389728,
  "story_title": "Mineral hints at bright blue rocks deep in the Earth",
  "story_url": "http://www.bbc.com/news/science-environment-26553115",
  "author": "mlla",
  "points": 1,
  "timestamp": 1394704844,
  "comment_id": "7390857",
  "parent_id": 7389984,
}
```
## Solution
#### Prerequisites
- glance over [the hacker news comments section](https://news.ycombinator.com/newcomments)
- [Algolia hacker news API](http://hn.algolia.com/api)
- [Requests library](http://docs.python-requests.org/en/latest/)
#### TODO
- [ ] Create a skeleton class
- [ ] Implement comment scraping
### Testing

Use mocking for response handling
- [x] all fields are returned
- [x] going back more than the supported number of pages raises an Exception
- [x] when the API doesn't return anything, nothing is yielded and it doesn't break the code 
